### PR TITLE
Add write modes to the Postman -> Scenarios conversion script.

### DIFF
--- a/convert_from_postman.js
+++ b/convert_from_postman.js
@@ -3,12 +3,18 @@ var _ = require('underscore');
 
 var postmanToScenario = require('./lib/postman_to_scenario');
 var scenarioCleaner = require('./lib/clean_postman_scenario');
+var scenarioWriter = require('./lib/write_scenarios')
 
 var argv = require('yargs')
     .alias('c', 'collection')
     .describe('c', 'Path of an exported Postman collection, v2')
     .alias('o', 'output')
     .describe('o', 'Path to output a new scenarios file')
+    .alias('m', 'mode')
+    .describe('m', 'Write mode: overwrite the scenarios file, append to it (failing if any scenarios already exist),' +
+                   ' or create + update existing scenarios in the file')
+    .choices('m', scenarioWriter.MODES)
+    .default('m', scenarioWriter.MODE_APPEND)
     .demandOption(['collection', 'output'])
     .argv;
 
@@ -19,8 +25,6 @@ console.log('');
 var scenarios = postmanToScenario.postmanCollectionToScenarios(collection);
 scenarioCleaner.cleanPostmanScenarios(scenarios);
 
-var scenariosJson = JSON.stringify(scenarios, null, '  ');
-
-fs.writeFileSync(argv.output, scenariosJson);
+scenarioWriter.writeScenarios(argv.mode, scenarios, argv.output);
 
 console.log('\nConversion completed successfully. Before using your scenario file, please address any warnings and/or remove any unsanitized data.');

--- a/lib/write_scenarios.js
+++ b/lib/write_scenarios.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const _ = require('underscore');
+const arrayOps = require('./array_operations')
+
+const MODE_OVERWRITE = 'overwrite';
+const MODE_APPEND = 'append';
+const MODE_UPDATE = 'update';
+
+const MODES = [MODE_OVERWRITE, MODE_APPEND, MODE_UPDATE];
+
+const modeSelector = {};
+modeSelector[MODE_OVERWRITE] = overwrite;
+modeSelector[MODE_APPEND] = append;
+modeSelector[MODE_UPDATE] = update;
+
+function writeScenarios(mode, newScenarios, targetFile) {
+    let write = modeSelector[mode];
+    write(newScenarios, targetFile);
+}
+
+function overwrite(newScenarios, targetFile) {
+    verifyNoDuplicateScenarios(
+        newScenarios,
+        'The collection file has duplicate scenarios',
+        'Remove duplicates from the collection and resubmit.');
+
+    writeToFile(newScenarios, targetFile);
+}
+
+function append(newScenarios, targetFile) {
+    if (!fs.existsSync(targetFile)) {
+        //No file to append to; just 'overwrite'
+        overwrite(newScenarios, targetFile);
+        return;
+    }
+
+    let currentScenarios = jsonFromFile(targetFile);
+    let allScenarios = currentScenarios.concat(newScenarios);
+
+    verifyNoDuplicateScenarios(
+        allScenarios,
+        'Appending this collection to the existing scenarios will create duplicate scenario names',
+        'To resolve, either:' +
+            '\n\ta. Edit either the existing or new scenario file to remove duplicates' +
+            '\n\tb. Use update mode to automatically replace conflicting scenarios with new ones' +
+            '\n\tc. Use overwrite mode to fully replace the old scenario file with the new one');
+
+    writeToFile(allScenarios, targetFile);
+}
+
+function update(newScenarios, targetFile) {
+    if (!fs.existsSync(targetFile)) {
+        //No file to update; just 'overwrite'
+        overwrite(newScenarios, targetFile);
+        return;
+    }
+
+    verifyNoDuplicateScenarios(
+        newScenarios,
+        'The collection file has duplicate scenarios',
+        'Remove duplicates from the collection and resubmit.');
+
+    let currentScenarios = jsonFromFile(targetFile);
+    let currentScenariosByName = _.indexBy(currentScenarios, 'scenario');
+    let newScenariosByName = _.indexBy(newScenarios, 'scenario');
+    let updatedScenariosByName = Object.assign(currentScenariosByName, newScenariosByName);
+    let updatedScenarios = _.values(updatedScenariosByName);
+
+    writeToFile(updatedScenarios, targetFile);
+}
+
+function verifyNoDuplicateScenarios(scenarios, cause, recommendation) {
+    let scenarioNames = _.pluck(scenarios, 'scenario');
+    let duplicateScenarioNames = arrayOps.getDuplicateElements(scenarioNames, (x, y) => x === y);
+
+    if (duplicateScenarioNames.length === 0) return;
+    
+    let duplicateNamesString = JSON.stringify(duplicateScenarioNames);
+
+    console.error(`${cause}:\n\t${duplicateNamesString}\n${recommendation}`);
+    
+    process.exit(1);
+}
+
+const jsonFromFile = (file) => JSON.parse(fs.readFileSync(file));
+
+function writeToFile(scenarios, targetFile) {
+    let output = JSON.stringify(scenarios, null, '  ');
+    fs.writeFileSync(targetFile, output);
+}
+
+exports.writeScenarios = writeScenarios;
+exports.MODES = MODES;
+exports.MODE_OVERWRITE = MODE_OVERWRITE;
+exports.MODE_APPEND = MODE_APPEND;
+exports.MODE_UPDATE = MODE_UPDATE;

--- a/lib/write_scenarios.js
+++ b/lib/write_scenarios.js
@@ -2,19 +2,24 @@ const fs = require('fs');
 const _ = require('underscore');
 const arrayOps = require('./array_operations')
 
-const MODE_OVERWRITE = 'overwrite';
 const MODE_APPEND = 'append';
+const MODE_OVERWRITE = 'overwrite';
 const MODE_UPDATE = 'update';
 
-const MODES = [MODE_OVERWRITE, MODE_APPEND, MODE_UPDATE];
+const MODES = [MODE_APPEND, MODE_OVERWRITE, MODE_UPDATE];
 
 const modeSelector = {};
-modeSelector[MODE_OVERWRITE] = overwrite;
 modeSelector[MODE_APPEND] = append;
+modeSelector[MODE_OVERWRITE] = overwrite;
 modeSelector[MODE_UPDATE] = update;
 
 function writeScenarios(mode, newScenarios, targetFile) {
     let write = modeSelector[mode];
+
+    if (!write) {
+        throw new Error(`Unknown mode ${mode}; valid modes:\n\t${JSON.stringify(MODES)}\n`);
+    }
+
     write(newScenarios, targetFile);
 }
 
@@ -24,17 +29,17 @@ function overwrite(newScenarios, targetFile) {
         'The collection file has duplicate scenarios',
         'Remove duplicates from the collection and resubmit.');
 
-    writeToFile(newScenarios, targetFile);
+    file.write(newScenarios, targetFile);
 }
 
 function append(newScenarios, targetFile) {
-    if (!fs.existsSync(targetFile)) {
+    if (file.notPresent(targetFile)) {
         //No file to append to; just 'overwrite'
         overwrite(newScenarios, targetFile);
         return;
     }
 
-    let currentScenarios = jsonFromFile(targetFile);
+    let currentScenarios = file.toJson(targetFile);
     let allScenarios = currentScenarios.concat(newScenarios);
 
     verifyNoDuplicateScenarios(
@@ -45,11 +50,11 @@ function append(newScenarios, targetFile) {
             '\n\tb. Use update mode to automatically replace conflicting scenarios with new ones' +
             '\n\tc. Use overwrite mode to fully replace the old scenario file with the new one');
 
-    writeToFile(allScenarios, targetFile);
+    file.write(allScenarios, targetFile);
 }
 
 function update(newScenarios, targetFile) {
-    if (!fs.existsSync(targetFile)) {
+    if (file.notPresent(targetFile)) {
         //No file to update; just 'overwrite'
         overwrite(newScenarios, targetFile);
         return;
@@ -60,13 +65,13 @@ function update(newScenarios, targetFile) {
         'The collection file has duplicate scenarios',
         'Remove duplicates from the collection and resubmit.');
 
-    let currentScenarios = jsonFromFile(targetFile);
+    let currentScenarios = file.toJson(targetFile);
     let currentScenariosByName = _.indexBy(currentScenarios, 'scenario');
     let newScenariosByName = _.indexBy(newScenarios, 'scenario');
     let updatedScenariosByName = Object.assign(currentScenariosByName, newScenariosByName);
     let updatedScenarios = _.values(updatedScenariosByName);
 
-    writeToFile(updatedScenarios, targetFile);
+    file.write(updatedScenarios, targetFile);
 }
 
 function verifyNoDuplicateScenarios(scenarios, cause, recommendation) {
@@ -77,20 +82,21 @@ function verifyNoDuplicateScenarios(scenarios, cause, recommendation) {
     
     let duplicateNamesString = JSON.stringify(duplicateScenarioNames);
 
-    console.error(`${cause}:\n\t${duplicateNamesString}\n${recommendation}`);
-    
-    process.exit(1);
+    throw new Error(`${cause}:\n\t${duplicateNamesString}\n${recommendation}\n`);
 }
 
-const jsonFromFile = (file) => JSON.parse(fs.readFileSync(file));
-
-function writeToFile(scenarios, targetFile) {
-    let output = JSON.stringify(scenarios, null, '  ');
-    fs.writeFileSync(targetFile, output);
+const file = {
+    notPresent: f => !fs.existsSync(f),
+    toJson: f => JSON.parse(fs.readFileSync(f)),
+    write: function(scenarios, f) {
+        let output = JSON.stringify(scenarios, null, '  ');
+        fs.writeFileSync(f, output);
+    }
 }
 
 exports.writeScenarios = writeScenarios;
 exports.MODES = MODES;
-exports.MODE_OVERWRITE = MODE_OVERWRITE;
 exports.MODE_APPEND = MODE_APPEND;
+exports.MODE_OVERWRITE = MODE_OVERWRITE;
 exports.MODE_UPDATE = MODE_UPDATE;
+exports.private = { file };

--- a/test/write_scenarios_test.js
+++ b/test/write_scenarios_test.js
@@ -1,0 +1,173 @@
+var should = require('should');
+
+var scenarioWriter = require('../lib/write_scenarios.js');
+
+describe('Write Scenarios Test', () => {
+    beforeEach(() => {
+        scenarioWriter.private.file.write = () => {};
+    });
+
+    describe('Invalid mode inputs', () => {
+        it('Rejects invalid modes', () => {
+            givenTargetFileMissing();
+
+            let scenario = getValidInputScenario();
+            (() => scenarioWriter.writeScenarios('Not a mode', scenario, 'target')).should.throw();
+        });
+    });
+
+    describe('Overwrite mode', () => {
+        it('Rejects duplicate input scenarios', () => {
+            givenTargetFileMissing();
+            
+            let scenarios = getTwoScenariosWithSameName();
+            (() => scenarioWriter.writeScenarios(
+                scenarioWriter.MODE_OVERWRITE,
+                scenario,
+                'target')
+            ).should.throw();
+        });
+
+        it('Writes the file if it is missing', () => {
+            givenTargetFileMissing();
+
+            let scenarios = getValidInputScenario();
+            expectScenariosToBeWritten(scenarios, 'target');
+            scenarioWriter.writeScenarios(scenarioWriter.MODE_OVERWRITE, scenarios, 'target');
+        });
+
+        it('Replaces the file if it exists', () => {
+            let [scenarioA, scenarioB] = getTwoDifferentScenarios();
+
+            givenTargetFileContainsScenarios([scenarioA]);
+            expectScenariosToBeWritten([scenarioB], 'target');
+            scenarioWriter.writeScenarios(scenarioWriter.MODE_OVERWRITE, [scenarioB], 'target');
+        });
+
+        it('Replaces the file even if it contains any of the input scenarios', () => {
+            let [scenarioA, scenarioB] = getTwoScenariosWithSameName();
+
+            givenTargetFileContainsScenarios([scenarioA]);
+            expectScenariosToBeWritten([scenarioB], 'target');
+            scenarioWriter.writeScenarios(scenarioWriter.MODE_OVERWRITE, [scenarioB], 'target');
+        });
+    });
+
+    describe('Append mode', () => {
+        it('Rejects duplicate input scenarios', () => {
+            givenTargetFileMissing();
+            
+            let scenarios = getTwoScenariosWithSameName();
+            (() => scenarioWriter.writeScenarios(
+                scenarioWriter.MODE_APPEND,
+                scenario,
+                'target')
+            ).should.throw();
+        });
+
+        it('Writes the file if it is missing', () => {
+            givenTargetFileMissing();
+
+            let scenarios = getValidInputScenario();
+            expectScenariosToBeWritten(scenarios, 'target');
+            scenarioWriter.writeScenarios(scenarioWriter.MODE_APPEND, scenarios, 'target');
+        });
+
+        it('Appends scenarios to the file if it exists', () => {
+            let [scenarioA, scenarioB] = getTwoDifferentScenarios();
+
+            givenTargetFileContainsScenarios([scenarioA]);
+            expectScenariosToBeWritten([scenarioA, scenarioB], 'target');
+            scenarioWriter.writeScenarios(scenarioWriter.MODE_APPEND, [scenarioB], 'target');
+        });
+
+        it('Rejects scenarios if they match any scenarios in the existing file', () => {
+            let [scenarioA, scenarioB] = getTwoScenariosWithSameName();
+
+            givenTargetFileContainsScenarios([scenarioA]);
+            (() => scenarioWriter.writeScenarios(
+                scenarioWriter.MODE_APPEND,
+                [scenarioB],
+                'target')
+            ).should.throw();
+        });
+    });
+
+    describe('Update mode', () => {
+        it('Rejects duplicate input scenarios', () => {
+            givenTargetFileMissing();
+            
+            let scenarios = getTwoScenariosWithSameName();
+            (() => scenarioWriter.writeScenarios(
+                scenarioWriter.MODE_UPDATE,
+                scenario,
+                'target')
+            ).should.throw();
+        });
+
+        it('Writes the file if it is missing', () => {
+            givenTargetFileMissing();
+
+            let scenarios = getValidInputScenario();
+            expectScenariosToBeWritten(scenarios, 'target');
+            scenarioWriter.writeScenarios(scenarioWriter.MODE_UPDATE, scenarios, 'target');
+        });
+
+        it('Appends new scenarios to existing files', () => {
+            let [scenarioA, scenarioB] = getTwoDifferentScenarios();
+
+            givenTargetFileContainsScenarios([scenarioA]);
+            expectScenariosToBeWritten([scenarioA, scenarioB], 'target');
+            scenarioWriter.writeScenarios(scenarioWriter.MODE_UPDATE, [scenarioB], 'target');
+        });
+
+        it('Updates existing scenarios in existing files', () => {
+            let [scenarioA, scenarioB] = getTwoScenariosWithSameName();
+
+            givenTargetFileContainsScenarios([scenarioA]);
+            expectScenariosToBeWritten([scenarioB], 'target');
+            scenarioWriter.writeScenarios(scenarioWriter.MODE_UPDATE, [scenarioB], 'target');
+        });
+    });
+
+    function getValidInputScenario() {
+        return [{ scenario: 'x' }];
+    }
+
+    function getTwoDifferentScenarios() {
+        return [{
+            scenario: 'x',
+            value: 1
+        }, {
+            scenario: 'y',
+            value: 2
+        }];
+    }
+
+    function getTwoScenariosWithSameName() {
+        return [{
+            scenario: 'x',
+            value: 1
+        }, {
+            scenario: 'x',
+            value: 2
+        }];
+    }
+
+    function givenTargetFileMissing() {
+        scenarioWriter.private.file.notPresent = () => true;
+        scenarioWriter.private.file.toJson = () => { throw new Error('No target file'); }
+    }
+
+    function givenTargetFileContainsScenarios(scenarios) {
+        scenarioWriter.private.file.notPresent = () => false;
+        scenarioWriter.private.file.toJson = () => scenarios;
+    }
+
+    function expectScenariosToBeWritten(scenarios, file) {
+        scenarioWriter.private.write = (inScenarios, inFile) => {
+            inScenarios.should.equal(scenarios);
+            inFile.should.equal(file);
+        };
+    }
+});


### PR DESCRIPTION
The script `convert_from_postman.js` now has three operating modes that can be selected:

* `overwrite` - Totally replaces the scenarios file with the Postman scenarios
* `append` - Adds the new Postman scenarios to the existing scenarios
* `update` - Adds new Postman scenarios and updates any matching existing scenarios with their Postman counterparts

Use the `-m` or `--mode` flag to set the mode.  The default mode is now `append`, as it is the least destructive mode.  All three modes will generate a visible error if the target file would have duplicate scenarios; the user of the script will be instructed on how to correct the duplication.